### PR TITLE
Add parameter `output-file` to action

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -31,6 +31,10 @@ inputs:
     required: false
     default: 'stdout'
 
+  output-file:
+    description: 'Output file'
+    required: false
+
   fail-on-result:
     description: 'Enable or disable fail if results were found'
     required: false
@@ -52,6 +56,7 @@ runs:
     - ${{ inputs.fail-on-result }}
     - ${{ inputs.suggest-fix }}
     - ${{ inputs.database-strategy }}
+    - ${{ inputs.output-file }}
 
 branding:
   color: gray-dark

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,6 +42,10 @@ if [[ ! -z $database_strategy ]]; then
   output_cmd="${output_cmd} -t ${database_strategy}";
 fi
 
+if [[ ! -z $output_file ]]; then
+  output_cmd="${output_cmd} > ${output_file}";
+fi
+
 cd /github/workspace/
 
 bash -c "${output_cmd}"


### PR DESCRIPTION
So customers can specify a output file name through the parameter.

For example:
```
      - name: Dependency scan
        uses: clj-holmes/clj-watson-action@992d0e6270ab50ac6f7d8709f323a77cfa816b66
        with:
          clj-watson-sha: "992d0e6"
          clj-watson-tag: "v3.0.2-ALPHA"
          database-strategy: github-advisory
          aliases: clojure-lsp,test 
          deps-edn-path: deps.edn
          suggest-fix: true
          output-type: sarif
          output-file: clj-watson-results.sarif
```

@mthbernardes @eddynaka pls review